### PR TITLE
make check dependent on jacocoTestReport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,4 @@ jacocoTestReport {
         html.enabled false
     }
 }
+check.dependsOn jacocoTestReport


### PR DESCRIPTION
This pull request fixes problem with jacoco test results and solves [issue](https://github.com/codecov/example-gradle/issues/1)
After build __jacocoTestReport.xml__ will be at __example-gradle/build/reports/jacoco/test__.
