### PR TITLE
#14 Fix jacoco xml report destination in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ task codeCoverageReport(type: JacocoReport) {
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/report.xml"
+        xml.destination file("${buildDir}/reports/jacoco/report.xml")
         html.enabled false
         csv.enabled false
     }


### PR DESCRIPTION
hi, i have used gradle-5.1 to execute codeCoverageReport command, it throw exception as follow, and i solve this problem when i change `xml.destination "${buildDir}/reports/jacoco/report.xml"` to `xml.destination file("${buildDir}/reports/jacoco/report.xml")`

```
➜  micro-service-gradle git:(master) gradle clean test codeCoverageReport        
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/anmy/workspace/workspace-new/micro-service-lab/micro-service-gradle/build.gradle' line: 74

* What went wrong:
A problem occurred evaluating root project 'micro-service-gradle'.
> Could not find method destination() for arguments [/Users/anmy/workspace/workspace-new/micro-service-lab/micro-service-gradle/build/reports/jacoco/report.xml] on Report xml of type org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
```